### PR TITLE
[CI-1137]: Removed IdeHelperServiceProvider from providers

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -169,7 +169,6 @@ return [
         Crater\Providers\RouteServiceProvider::class,
         Crater\Providers\DropboxServiceProvider::class,
         Crater\Providers\ViewServiceProvider::class,
-        Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
     ],
 
     /*


### PR DESCRIPTION
created by @khatriafaz 
Closes https://github.com/crater-invoice/crater/issues/1137

## Description

## Related Issue
closes #1137

## Motivation and Context
- Removes serviceprovider, so it can get autodiscovered by Laravel

## Pull Request Checklist
  * [X] I have an issue ID for this pull request: #1137

## Issue Type (Please check one or more)
  * [X] Bugfix